### PR TITLE
MDX fixup

### DIFF
--- a/src/components/post-layout.js
+++ b/src/components/post-layout.js
@@ -53,15 +53,15 @@ export default ({data}) => {
                 </header>
             
                 <div>
-                    {/* <MDXRenderer>{post.code.body}</MDXRenderer>  */}
+                  <MDXRenderer>{data.mdx.code.body}</MDXRenderer>
                 </div>
             </div>
         </Layout>
     )
 }
 
-export const query = graphql`
-    query PostQuery($postRoute: String!) {
+export const pageQuery = graphql`
+    query ($postRoute: String!) {
         mdx(fields: {route: {eq: $postRoute}}){
                 frontmatter{
                     title


### PR DESCRIPTION
* MDXRenderer needed to be uncommented and used in the JSX tree
* the query needs to be named pageQuery for gatsby-mdx to pick it up
  - idk when gatsby started supporting `query` as the export name but we need to update it in gatsby-mdx.
* pageQuery needs to be nameless so it's hashed appropriately automatically by gatsby when run